### PR TITLE
Fix getKernelpath()

### DIFF
--- a/libgrabkernel/libgrabkernel.m
+++ b/libgrabkernel/libgrabkernel.m
@@ -115,9 +115,8 @@ char *getKernelpath(const char *buildmanifestPath, const char *model){
         for (NSDictionary *item in identities) {
             NSDictionary *info = [item valueForKey:@"Info"];
             NSString *hwmodel = [info valueForKey:@"DeviceClass"];
-            hwmodel = hwmodel.uppercaseString;
             
-            if (strcmp(hwmodel.UTF8String, model) == 0) {
+            if (strcasecmp(hwmodel.UTF8String, model) == 0) {
                 NSDictionary *manifest = [item valueForKey:@"Manifest"];
                 NSDictionary *kcache = [manifest valueForKey:@"KernelCache"];
                 NSDictionary *kinfo = [kcache valueForKey:@"Info"];


### PR DESCRIPTION
getKernelpath() would not recognize a correct match, if the hwmodel string and the provided model string would not have the same capitalization. This is fixed by replacing strcmp() with strcasecmp() which should work in every case, no matter the capitalization of hwmodel and model.

This was noticed when getHWModel() correctly detected the device to be J71bAP (iPad 9.7" 2018), but the build manifest listed the device as j71bap and getKernelpath() would not find the matching entry correctly. This should theoretically now work correctly for every device/hwmodel combination.